### PR TITLE
 Add ALLOW_SLIPPERY_TOUCHES to make StatusBarTouchController slippery 

### DIFF
--- a/prebuilts/api/30.0/private/adbd.te
+++ b/prebuilts/api/30.0/private/adbd.te
@@ -162,6 +162,9 @@ allow adbd sepolicy_file:file r_file_perms;
 # Allow pulling config.gz for CTS purposes
 allow adbd config_gz:file r_file_perms;
 
+# For CTS listening ports test.
+allow adbd proc_net_tcp_udp:file r_file_perms;
+
 allow adbd gpu_service:service_manager find;
 allow adbd surfaceflinger_service:service_manager find;
 allow adbd bootchart_data_file:dir search;

--- a/private/adbd.te
+++ b/private/adbd.te
@@ -162,6 +162,9 @@ allow adbd sepolicy_file:file r_file_perms;
 # Allow pulling config.gz for CTS purposes
 allow adbd config_gz:file r_file_perms;
 
+# For CTS listening ports test.
+allow adbd proc_net_tcp_udp:file r_file_perms;
+
 allow adbd gpu_service:service_manager find;
 allow adbd surfaceflinger_service:service_manager find;
 allow adbd bootchart_data_file:dir search;


### PR DESCRIPTION
Allow adbd to access /proc/net/{tcp,tcp6,udp,udp6}

File accesses go through com.android.ddmlib.SyncService for CTS ListeningPortsTest.

Bug: 201645790
Test: atest ListeningPortsTest
Ignore-AOSP-First: Fix already in AOSP
Change-Id: I0c66fb5e35cda3b1799cf003402e454d7a951e96 (cherry picked from commit 1a6b37d838459b3d46cc06e31bc3c2bf5e7c387f) Merged-In:I0c66fb5e35cda3b1799cf003402e454d7a951e96